### PR TITLE
fix paths with spaces

### DIFF
--- a/setup_xcode_environment.sh
+++ b/setup_xcode_environment.sh
@@ -57,7 +57,7 @@ then
             read -p "New paths found, replace? [y/N] : " yn
             case $yn in
                 [Yy]* )
-                    (replace_paths $file_path $JAVA_HOME $ANDROID_SDK_ROOT);
+                    (replace_paths "$file_path" "$JAVA_HOME" "$ANDROID_SDK_ROOT");
                     exit;;
                 [Nn]* ) exit;;
                 * ) echo "Please answer y/n.";;
@@ -78,18 +78,18 @@ else
     java_path=""
     android_sdk_path=""
     if [ $JAVA_HOME ] && [ -d "$JAVA_HOME" ]; then
-        java_path=$JAVA_HOME
+        java_path="$JAVA_HOME"
     else
         echo "Enter JAVA_HOME path: "
         read java_path
     fi
 
     if [ $ANDROID_SDK_ROOT ] && [ -d "$ANDROID_SDK_ROOT"]; then
-        android_sdk_path=$ANDROID_SDK_ROOT
+        android_sdk_path="$ANDROID_SDK_ROOT"
     else
         echo "Enter ANDROID_SDK_ROOT path: "
         read android_sdk_path
     fi
 
-    replace_paths $file_path $java_path $android_sdk_path;
+    replace_paths "$file_path" "$java_path" "$android_sdk_path";
 fi

--- a/setup_xcode_environment_extended.sh
+++ b/setup_xcode_environment_extended.sh
@@ -101,25 +101,25 @@ else
 	gradle_user_home=""
 	konan_data_dir=""
 	if [ "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ]; then
-		java_path=$JAVA_HOME
+		java_path="$JAVA_HOME"
 	else
 		echo "Enter JAVA_HOME path: "
 		read java_path
 	fi
 	if [ "$ANDROID_SDK_ROOT" ] && [ -d "$ANDROID_SDK_ROOT" ]; then
-		android_sdk_path=$ANDROID_SDK_ROOT
+		android_sdk_path="$ANDROID_SDK_ROOT"
 	else
 		echo "Enter ANDROID_SDK_ROOT path: "
 		read android_sdk_path
 	fi
 	if [ "$GRADLE_USER_HOME" ] && [ -d "$GRADLE_USER_HOME" ]; then
-		gradle_user_home=$GRADLE_USER_HOME
+		gradle_user_home="$GRADLE_USER_HOME"
 	else
 		echo "Enter GRADLE_USER_HOME path: "
 		read gradle_user_home
 	fi
 	if [ "$KONAN_DATA_DIR" ] && [ -d "$KONAN_DATA_DIR" ]; then
-		konan_data_dir=$KONAN_DATA_DIR
+		konan_data_dir="$KONAN_DATA_DIR"
 	else
 		echo "Enter KONAN_DATA_DIR path: "
 		read konan_data_dir


### PR DESCRIPTION
Quote references to paths so that spaces in the paths don't break at the space.

In my case I was using a java home in the Android Studio install which was in `Applications/Android Studio.app`

The script was unable to set the path in Xcode prior to the changes but works for me with this.

I don't have a lot of experience in bash scripting so please review this for any unintended changes.

Closes #10 